### PR TITLE
Correct issue with FormSelectUser

### DIFF
--- a/htdocs/modules/system/themes/default/xotpl/xo_tabs.tpl
+++ b/htdocs/modules/system/themes/default/xotpl/xo_tabs.tpl
@@ -1,10 +1,10 @@
 <!-- the tabs -->
 <ul class="tabs">
     <li><a class="tooltip" href="#" title="<{$smarty.const._AM_SYSTEM_HELP}>"><img src='<{"$theme_icons/help.png"}>'/></a></li>
-    <li><a class="tooltip" href="#" title="<{block id=4 display=" title"}>"><img src='<{"$theme_icons/waiting.png"}>'/></a></li>
-    <li><a class="tooltip" href="#" title="<{block id=9 display=" title"}>"><img src='<{"$theme_icons/edituser.png"}>'/></a></li>
-    <li><a class="tooltip" href="#" title="<{block id=8 display=" title"}>"><img src='<{"$theme_icons/newuser.png"}>'/></a></li>
-    <li><a class="tooltip" href="#" title="<{block id=10 display=" title"}>"><img src='<{"$theme_icons/comments.png"}>'/></a></li>
+    <li><a class="tooltip" href="#" title="<{block id=4 display='title'}>"><img src='<{"$theme_icons/waiting.png"}>'/></a></li>
+    <li><a class="tooltip" href="#" title="<{block id=9 display='title'}>"><img src='<{"$theme_icons/edituser.png"}>'/></a></li>
+    <li><a class="tooltip" href="#" title="<{block id=8 display='title'}>"><img src='<{"$theme_icons/newuser.png"}>'/></a></li>
+    <li><a class="tooltip" href="#" title="<{block id=10 display='title'}>"><img src='<{"$theme_icons/comments.png"}>'/></a></li>
 </ul>
 
 <!-- tab "panes" -->


### PR DESCRIPTION
Full user list was not included when pre-selected values were specified.

Now follows this pattern:
- add anonymous user if $includeAnonymous specified
- add any user(s) specified in $value
- union these with full user list, or the 200 most recently logged in users

The list is cached to reduce thrashing on systems with large user bases.

Also includes fix for issue in an admin area template,