### PR TITLE
Eliminate PHP 4 style constructor

### DIFF
--- a/htdocs/Frameworks/art/object.php
+++ b/htdocs/Frameworks/art/object.php
@@ -42,11 +42,6 @@ class ArtObject extends XoopsObject
     public function __construct()
     {
     }
-
-    public function ArtObject()
-    {
-        $this->__construct();
-    }
 }
 
 /**
@@ -73,22 +68,10 @@ class ArtObjectHandler extends XoopsPersistableObjectHandler
      * @param string $identifierName
      */
 
-    public function __construct(XoopsDatabase $db, $table, $className, $keyName, $identifierName)
+    public function __construct(XoopsDatabase $db, $table = "", $className = "", $keyName = "", $identifierName = false)
     {
         $this->db = $db;
         parent::__construct($db, $table, $className, $keyName, $identifierName);
-    }
-
-    /**
-     * @param XoopsDatabase $db
-     * @param string $table
-     * @param string $className
-     * @param string $keyName
-     * @param bool   $identifierName
-     */
-    public function ArtObjectHandler(XoopsDatabase $db, $table = "", $className = "", $keyName = "", $identifierName = false)
-    {
-        $this->__construct($db, $table, $className, $keyName, $identifierName);
     }
 
     /**

--- a/htdocs/Frameworks/art/xoopsart.php
+++ b/htdocs/Frameworks/art/xoopsart.php
@@ -19,11 +19,6 @@ class xoopsart
     {
     }
 
-    public function XoopsArt()
-    {
-        $this->__construct();
-    }
-
     /**
      * Load a collective functions of Frameworks
      *

--- a/htdocs/class/cache/model.php
+++ b/htdocs/class/cache/model.php
@@ -202,11 +202,6 @@ class XoopsCacheModel extends XoopsCacheEngine
  */
 class XoopsCacheModelObject extends XoopsObject
 {
-    public function XoopsCacheModelObject()
-    {
-        $this->__construct();
-    }
-
     /**
      * Constructor
      */

--- a/htdocs/class/captcha/image/scripts/image.php
+++ b/htdocs/class/captcha/image/scripts/image.php
@@ -56,11 +56,6 @@ class XoopsCaptchaImageHandler
         $this->config          = $this->captcha_handler->loadConfig("image");
     }
 
-    public function XoopsCaptchaImageHandler()
-    {
-        $this->__construct();
-    }
-
     public function loadImage()
     {
         $this->generateCode();

--- a/htdocs/class/captcha/xoopscaptcha.php
+++ b/htdocs/class/captcha/xoopscaptcha.php
@@ -49,16 +49,6 @@ class XoopsCaptcha
     }
 
     /**
-     * Xoops Captcha Construct
-     *
-     * @return XoopsCaptcha
-     */
-    public function XoopsCaptcha()
-    {
-        $this->__construct();
-    }
-
-    /**
      * Get Instance
      *
      * @return Instance
@@ -382,16 +372,6 @@ class XoopsCaptchaMethod
     public function __construct($handler = null)
     {
         $this->handler = $handler;
-    }
-
-    /**
-     * XoopsCaptchaMethod::XoopsCaptchaMethod()
-     *
-     * @param mixed $handler
-     */
-    public function XoopsCaptchaMethod($handler = null)
-    {
-        $this->__construct($handler);
     }
 
     /**

--- a/htdocs/class/class.tar.php
+++ b/htdocs/class/class.tar.php
@@ -122,11 +122,6 @@ class tar
         return true;
     }
 
-    public function tar()
-    {
-        $this->__construct();
-    }
-
     /**
      * Computes the unsigned Checksum of a file's header
      * to try to ensure valid file

--- a/htdocs/class/commentrenderer.php
+++ b/htdocs/class/commentrenderer.php
@@ -64,16 +64,6 @@ class XoopsCommentRenderer
     }
 
     /**
-     * @param XoopsTpl   $tpl
-     * @param bool|true  $use_icons
-     * @param bool|false $do_iconcheck
-     */
-    public function XoopsCommentRenderer(XoopsTpl $tpl, $use_icons = true, $do_iconcheck = false)
-    {
-        $this->__construct($tpl, $use_icons, $do_iconcheck);
-    }
-
-    /**
      * Access the only instance of this class
      *
      * @param  XoopsTpl $tpl reference to a {@link Smarty} object

--- a/htdocs/class/criteria.php
+++ b/htdocs/class/criteria.php
@@ -70,11 +70,6 @@ class CriteriaElement
     {
     }
 
-    public function CriteriaElement()
-    {
-        $this->__construct();
-    }
-
     /**
      * Render the criteria element
      */
@@ -212,15 +207,6 @@ class CriteriaCompo extends CriteriaElement
     }
 
     /**
-     * @param CriteriaElement|null $ele
-     * @param string               $condition
-     */
-    public function CriteriaCompo(CriteriaElement $ele = null, $condition = 'AND')
-    {
-        $this->__construct($ele, $condition);
-    }
-
-    /**
      * Add an element
      *
      * @param CriteriaElement|object $criteriaElement
@@ -328,18 +314,6 @@ class Criteria extends CriteriaElement
         $this->column   = $column;
         $this->value    = $value;
         $this->operator = $operator;
-    }
-
-    /**
-     * @param        $column
-     * @param string $value
-     * @param string $operator
-     * @param string $prefix
-     * @param string $function
-     */
-    public function Criteria($column, $value = '', $operator = '=', $prefix = '', $function = '')
-    {
-        $this->__construct($column, $value, $operator, $prefix, $function);
     }
 
     /**

--- a/htdocs/class/database/database.php
+++ b/htdocs/class/database/database.php
@@ -37,7 +37,7 @@ define('XOOPS_C_DATABASE_INCLUDED', 1);
  * @package    kernel
  * @subpackage database
  */
-class XoopsDatabase
+abstract class XoopsDatabase
 {
     /**
      * Prefix for tables in the database
@@ -67,16 +67,6 @@ class XoopsDatabase
     public function __construct()
     {
         // exit('Cannot instantiate this class directly');
-    }
-
-    /**
-     * constructor
-     *
-     * will always fail, because this is an abstract class!
-     */
-    public function XoopsDatabase()
-    {
-        $this->__construct();
     }
 
     /**

--- a/htdocs/class/database/databasefactory.php
+++ b/htdocs/class/database/databasefactory.php
@@ -34,14 +34,6 @@ class XoopsDatabaseFactory
     }
 
     /**
-     * XoopsDatabaseFactory::XoopsDatabaseFactory()
-     */
-    public function XoopsDatabaseFactory()
-    {
-        $this->__construct();
-    }
-
-    /**
      * Get a reference to the only instance of database class and connects to DB
      *
      * if the class has not been instantiated yet, this will also take

--- a/htdocs/class/downloader.php
+++ b/htdocs/class/downloader.php
@@ -45,11 +45,6 @@ class XoopsDownloader
         // EMPTY
     }
 
-    public function XoopsDownloader()
-    {
-        $this->__construct();
-    }
-
     /**
      * Send the HTTP header
      *

--- a/htdocs/class/file/file.php
+++ b/htdocs/class/file/file.php
@@ -119,18 +119,6 @@ class XoopsFileHandler
     }
 
     /**
-     * XoopsFileHandler::XoopsFileHandler()
-     *
-     * @param mixed $path
-     * @param mixed $create
-     * @param mixed $mode
-     */
-    public function XoopsFileHandler($path, $create = false, $mode = 0755)
-    {
-        $this->__construct($path, $create, $mode);
-    }
-
-    /**
      * Closes the current file if it is opened
      *
      * @access private

--- a/htdocs/class/file/folder.php
+++ b/htdocs/class/file/folder.php
@@ -134,16 +134,6 @@ class XoopsFolderHandler
     }
 
     /**
-     * @param      $path
-     * @param bool $create
-     * @param bool $mode
-     */
-    public function XoopsFolderHandler($path, $create = false, $mode = false)
-    {
-        $this->__construct($path, $create, $mode);
-    }
-
-    /**
      * Return current path.
      *
      * @return string Current path

--- a/htdocs/class/file/xoopsfile.php
+++ b/htdocs/class/file/xoopsfile.php
@@ -36,14 +36,6 @@ class XoopsFile
     }
 
     /**
-     * XoopsFile::XoopsFile()
-     */
-    public function XoopsFile()
-    {
-        $this->__construct();
-    }
-
-    /**
      * XoopsFile::getInstance()
      *
      * @return

--- a/htdocs/class/model/xoopsmodel.php
+++ b/htdocs/class/model/xoopsmodel.php
@@ -37,16 +37,8 @@ class XoopsModelFactory
     /**
      * XoopsModelFactory::__construct()
      */
-    public function __construct()
+    protected function __construct()
     {
-    }
-
-    /**
-     * XoopsModelFactory::XoopsModelFactory()
-     */
-    public function XoopsModelFactory()
-    {
-        $this->__construct();
     }
 
     /**
@@ -134,19 +126,6 @@ class XoopsModelAbstract
     {
         $this->setHandler($handler);
         $this->setVars($args);
-    }
-
-    /**
-     * XoopsModelAbstract::XoopsObjectAbstract()
-     *
-     * @param mixed $args
-     * @param mixed $handler
-     *
-     * @return void
-     */
-    public function XoopsObjectAbstract($args = null, $handler = null)
-    {
-        $this->__construct($args, $handler);
     }
 
     /**

--- a/htdocs/class/pagenav.php
+++ b/htdocs/class/pagenav.php
@@ -59,18 +59,6 @@ class XoopsPageNav
     }
 
     /**
-     * @param        $total_items
-     * @param        $items_perpage
-     * @param        $current_start
-     * @param string $start_name
-     * @param string $extra_arg
-     */
-    public function XoopsPageNav($total_items, $items_perpage, $current_start, $start_name = "start", $extra_arg = "")
-    {
-        $this->__construct($total_items, $items_perpage, $current_start, $start_name, $extra_arg);
-    }
-
-    /**
      * Create text navigation
      *
      * @param  integer $offset

--- a/htdocs/class/preload.php
+++ b/htdocs/class/preload.php
@@ -53,15 +53,10 @@ class XoopsPreload
      * Constructor
      *
      */
-    public function __construct()
+    protected function __construct()
     {
         $this->setPreloads();
         $this->setEvents();
-    }
-
-    public function XoopsPreload()
-    {
-        $this->__construct();
     }
 
     /**
@@ -166,10 +161,5 @@ class XoopsPreloadItem
      */
     public function __construct()
     {
-    }
-
-    public function XoopsPreloadItem()
-    {
-        $this->__construct();
     }
 }

--- a/htdocs/class/smarty/Config_File.class.php
+++ b/htdocs/class/smarty/Config_File.class.php
@@ -82,14 +82,6 @@ class Config_File
     }
 
     /**
-     * @param null $config_path
-     */
-    public function Config_File($config_path = null)
-    {
-        $this->__construct($config_path);
-    }
-
-    /**
      * Set the path where configuration files can be found.
      *
      * @param  string $config_path path to the config files

--- a/htdocs/class/smarty/Smarty.class.php
+++ b/htdocs/class/smarty/Smarty.class.php
@@ -576,11 +576,6 @@ class Smarty
         $this->assign('SCRIPT_NAME', isset($_SERVER['SCRIPT_NAME']) ? $_SERVER['SCRIPT_NAME'] : @$GLOBALS['HTTP_SERVER_VARS']['SCRIPT_NAME']);
     }
 
-    public function Smarty()
-    {
-        $this->__construct();
-    }
-
     /**
      * assigns values to template variables
      *

--- a/htdocs/class/smarty/Smarty_Compiler.class.php
+++ b/htdocs/class/smarty/Smarty_Compiler.class.php
@@ -202,11 +202,6 @@ class Smarty_Compiler extends Smarty
         $this->_func_call_regexp = '(?:' . $this->_func_regexp . '\s*(?:' . $this->_parenth_param_regexp . '))';
     }
 
-    public function Smarty_Compiler()
-    {
-        $this->__construct();
-    }
-
     /**
      * compile a resource
      *

--- a/htdocs/class/tardownloader.php
+++ b/htdocs/class/tardownloader.php
@@ -46,15 +46,6 @@ class XoopsTarDownloader extends XoopsDownloader
     }
 
     /**
-     * @param string $ext
-     * @param string $mimyType
-     */
-    public function XoopsTarDownloader($ext = '.tar.gz', $mimyType = 'application/x-gzip')
-    {
-        $this->__construct($ext, $mimyType);
-    }
-
-    /**
      * Add a file to the archive
      *
      * @param string $filepath    Full path to the file

--- a/htdocs/class/template.php
+++ b/htdocs/class/template.php
@@ -69,11 +69,6 @@ class XoopsTpl extends Smarty
                           'xoops_upload_url' => XOOPS_UPLOAD_URL));
     }
 
-    public function XoopsTpl()
-    {
-        $this->__construct();
-    }
-
     /**
      * Renders output from template data
      *

--- a/htdocs/class/tree.php
+++ b/htdocs/class/tree.php
@@ -59,17 +59,6 @@ class XoopsObjectTree
     }
 
     /**
-     * @param      $objectArr
-     * @param      $myId
-     * @param      $parentId
-     * @param null $rootId
-     */
-    public function XoopsObjectTree(&$objectArr, $myId, $parentId, $rootId = null)
-    {
-        $this->__construct($objectArr, $myId, $parentId, $rootId);
-    }
-
-    /**
      * Initialize the object
      *
      * @access private

--- a/htdocs/class/uploader.php
+++ b/htdocs/class/uploader.php
@@ -152,22 +152,6 @@ class XoopsMediaUploader
     }
 
     /**
-     * Constructor
-     *
-     * @param string $uploadDir
-     * @param array  $allowedMimeTypes
-     * @param int    $maxFileSize
-     * @param int    $maxWidth
-     * @param int    $maxHeight
-     * @param bool   $randomFilename
-     */
-
-    public function XoopsMediaUploader($uploadDir, $allowedMimeTypes, $maxFileSize = 0, $maxWidth = 0, $maxHeight = null, $randomFilename = false)
-    {
-        $this->__construct($uploadDir, $allowedMimeTypes, $maxFileSize, $maxWidth, $maxHeight, $randomFilename);
-    }
-
-    /**
      * converts memory/file sizes as defined in php.ini to bytes
      *
      * @param $size_str

--- a/htdocs/class/utility/xoopsutility.php
+++ b/htdocs/class/utility/xoopsutility.php
@@ -38,14 +38,6 @@ class XoopsUtility
     }
 
     /**
-     * XoopsUtility Constructor
-     */
-    public function XoopsUtility()
-    {
-        $this->__construct();
-    }
-
-    /**
      * XoopsUtility::recursive()
      *
      * @param mixed $handler

--- a/htdocs/class/xml/rpc/xmlrpcparser.php
+++ b/htdocs/class/xml/rpc/xmlrpcparser.php
@@ -119,14 +119,6 @@ class XoopsXmlRpcParser extends SaxParser
     }
 
     /**
-     * @param $input
-     */
-    public function XoopsXmlRpcParser(&$input)
-    {
-        $this->__construct($input);
-    }
-
-    /**
      * This Method starts the parsing of the specified RDF File. The File can be a local or a remote File.
      *
      * @param $name

--- a/htdocs/class/xml/rss/xmlrss2parser.php
+++ b/htdocs/class/xml/rss/xmlrss2parser.php
@@ -75,14 +75,6 @@ class XoopsXmlRss2Parser extends SaxParser
     }
 
     /**
-     * @param $input
-     */
-    public function XoopsXmlRss2Parser(&$input)
-    {
-        $this->__construct($input);
-    }
-
-    /**
      * @param $name
      * @param $value
      */
@@ -198,11 +190,6 @@ class RssChannelHandler extends XmlTagHandler
     {
     }
 
-    public function RssChannelHandler()
-    {
-        $this->__construct();
-    }
-
     /**
      * @return string
      */
@@ -222,11 +209,6 @@ class RssTitleHandler extends XmlTagHandler
      */
     public function __construct()
     {
-    }
-
-    public function RssTitleHandler()
-    {
-        $this->__construct();
     }
 
     /**
@@ -272,11 +254,6 @@ class RssLinkHandler extends XmlTagHandler
     {
     }
 
-    public function RssLinkHandler()
-    {
-        $this->__construct();
-    }
-
     /**
      * @return string
      */
@@ -318,11 +295,6 @@ class RssDescriptionHandler extends XmlTagHandler
      */
     public function __construct()
     {
-    }
-
-    public function RssDescriptionHandler()
-    {
-        $this->__construct();
     }
 
     /**
@@ -368,11 +340,6 @@ class RssGeneratorHandler extends XmlTagHandler
     {
     }
 
-    public function RssGeneratorHandler()
-    {
-        $this->__construct();
-    }
-
     /**
      * @return string
      */
@@ -407,11 +374,6 @@ class RssCopyrightHandler extends XmlTagHandler
      */
     public function __construct()
     {
-    }
-
-    public function RssCopyrightHandler()
-    {
-        $this->__construct();
     }
 
     /**
@@ -450,11 +412,6 @@ class RssNameHandler extends XmlTagHandler
     {
     }
 
-    public function RssNameHandler()
-    {
-        $this->__construct();
-    }
-
     /**
      * @return string
      */
@@ -489,11 +446,6 @@ class RssManagingEditorHandler extends XmlTagHandler
      */
     public function __construct()
     {
-    }
-
-    public function RssManagingEditorHandler()
-    {
-        $this->__construct();
     }
 
     /**
@@ -532,11 +484,6 @@ class RssLanguageHandler extends XmlTagHandler
     {
     }
 
-    public function RssLanguageHandler()
-    {
-        $this->__construct();
-    }
-
     /**
      * @return string
      */
@@ -571,11 +518,6 @@ class RssWebMasterHandler extends XmlTagHandler
      */
     public function __construct()
     {
-    }
-
-    public function RssWebMasterHandler()
-    {
-        $this->__construct();
     }
 
     /**
@@ -614,11 +556,6 @@ class RssDocsHandler extends XmlTagHandler
     {
     }
 
-    public function RssDocsHandler()
-    {
-        $this->__construct();
-    }
-
     /**
      * @return string
      */
@@ -653,11 +590,6 @@ class RssTtlHandler extends XmlTagHandler
      */
     public function __construct()
     {
-    }
-
-    public function RssTtlHandler()
-    {
-        $this->__construct();
     }
 
     /**
@@ -731,11 +663,6 @@ class RssLastBuildDateHandler extends XmlTagHandler
     {
     }
 
-    public function RssLastBuildDateHandler()
-    {
-        $this->__construct();
-    }
-
     /**
      * @return string
      */
@@ -772,11 +699,6 @@ class RssImageHandler extends XmlTagHandler
     {
     }
 
-    public function RssImageHandler()
-    {
-        $this->__construct();
-    }
-
     /**
      * @return string
      */
@@ -796,11 +718,6 @@ class RssUrlHandler extends XmlTagHandler
      */
     public function __construct()
     {
-    }
-
-    public function RssUrlHandler()
-    {
-        $this->__construct();
     }
 
     /**
@@ -835,11 +752,6 @@ class RssWidthHandler extends XmlTagHandler
     {
     }
 
-    public function RssWidthHandler()
-    {
-        $this->__construct();
-    }
-
     /**
      * @return string
      */
@@ -872,11 +784,6 @@ class RssHeightHandler extends XmlTagHandler
     {
     }
 
-    public function RssHeightHandler()
-    {
-        $this->__construct();
-    }
-
     /**
      * @return string
      */
@@ -907,11 +814,6 @@ class RssItemHandler extends XmlTagHandler
      */
     public function __construct()
     {
-    }
-
-    public function RssItemHandler()
-    {
-        $this->__construct();
     }
 
     /**
@@ -953,11 +855,6 @@ class RssCategoryHandler extends XmlTagHandler
     {
     }
 
-    public function RssCategoryHandler()
-    {
-        $this->__construct();
-    }
-
     /**
      * @return string
      */
@@ -997,11 +894,6 @@ class RssCommentsHandler extends XmlTagHandler
     {
     }
 
-    public function RssCommentsHandler()
-    {
-        $this->__construct();
-    }
-
     /**
      * @return string
      */
@@ -1032,11 +924,6 @@ class RssPubDateHandler extends XmlTagHandler
      */
     public function __construct()
     {
-    }
-
-    public function RssPubDateHandler()
-    {
-        $this->__construct();
     }
 
     /**
@@ -1076,11 +963,6 @@ class RssGuidHandler extends XmlTagHandler
      */
     public function __construct()
     {
-    }
-
-    public function RssGuidHandler()
-    {
-        $this->__construct();
     }
 
     /**
@@ -1142,11 +1024,6 @@ class RssSourceHandler extends XmlTagHandler
      */
     public function __construct()
     {
-    }
-
-    public function RssSourceHandler()
-    {
-        $this->__construct();
     }
 
     /**

--- a/htdocs/class/xml/themesetparser.php
+++ b/htdocs/class/xml/themesetparser.php
@@ -54,14 +54,6 @@ class XoopsThemeSetParser extends SaxParser
     }
 
     /**
-     * @param $input
-     */
-    public function XoopsThemeSetParser(&$input)
-    {
-        $this->__construct($input);
-    }
-
-    /**
      * @param $name
      * @param $value
      */
@@ -161,11 +153,6 @@ class ThemeSetDateCreatedHandler extends XmlTagHandler
     {
     }
 
-    public function ThemeSetDateCreatedHandler()
-    {
-        $this->__construct();
-    }
-
     /**
      * @return string
      */
@@ -200,11 +187,6 @@ class ThemeSetAuthorHandler extends XmlTagHandler
      */
     public function __construct()
     {
-    }
-
-    public function ThemeSetAuthorHandler()
-    {
-        $this->__construct();
     }
 
     /**
@@ -243,11 +225,6 @@ class ThemeSetDescriptionHandler extends XmlTagHandler
      */
     public function __construct()
     {
-    }
-
-    public function ThemeSetDescriptionHandler()
-    {
-        $this->__construct();
     }
 
     /**
@@ -289,11 +266,6 @@ class ThemeSetGeneratorHandler extends XmlTagHandler
     {
     }
 
-    public function ThemeSetGeneratorHandler()
-    {
-        $this->__construct();
-    }
-
     /**
      * @return string
      */
@@ -328,11 +300,6 @@ class ThemeSetNameHandler extends XmlTagHandler
      */
     public function __construct()
     {
-    }
-
-    public function ThemeSetNameHandler()
-    {
-        $this->__construct();
     }
 
     /**
@@ -374,11 +341,6 @@ class ThemeSetEmailHandler extends XmlTagHandler
     {
     }
 
-    public function ThemeSetEmailHandler()
-    {
-        $this->__construct();
-    }
-
     /**
      * @return string
      */
@@ -415,11 +377,6 @@ class ThemeSetLinkHandler extends XmlTagHandler
     {
     }
 
-    public function ThemeSetLinkHandler()
-    {
-        $this->__construct();
-    }
-
     /**
      * @return string
      */
@@ -454,11 +411,6 @@ class ThemeSetTemplateHandler extends XmlTagHandler
      */
     public function __construct()
     {
-    }
-
-    public function ThemeSetTemplateHandler()
-    {
-        $this->__construct();
     }
 
     /**
@@ -500,11 +452,6 @@ class ThemeSetImageHandler extends XmlTagHandler
     {
     }
 
-    public function ThemeSetImageHandler()
-    {
-        $this->__construct();
-    }
-
     /**
      * @return string
      */
@@ -544,11 +491,6 @@ class ThemeSetModuleHandler extends XmlTagHandler
     {
     }
 
-    public function ThemeSetModuleHandler()
-    {
-        $this->__construct();
-    }
-
     /**
      * @return string
      */
@@ -586,11 +528,6 @@ class ThemeSetFileTypeHandler extends XmlTagHandler
     {
     }
 
-    public function ThemeSetFileTypeHandler()
-    {
-        $this->__construct();
-    }
-
     /**
      * @return string
      */
@@ -625,11 +562,6 @@ class ThemeSetTagHandler extends XmlTagHandler
      */
     public function __construct()
     {
-    }
-
-    public function ThemeSetTagHandler()
-    {
-        $this->__construct();
     }
 
     /**

--- a/htdocs/class/xoopseditor/dhtmltextarea/dhtmltextarea.php
+++ b/htdocs/class/xoopseditor/dhtmltextarea/dhtmltextarea.php
@@ -55,16 +55,6 @@ class FormDhtmlTextArea extends XoopsEditor
     }
 
     /**
-     * FormDhtmlTextArea::FormDhtmlTextArea()
-     *
-     * @param array $options
-     */
-    public function FormDhtmlTextArea($options = array())
-    {
-        $this->__construct($options);
-    }
-
-    /**
      * FormDhtmlTextArea::render()
      *
      * @return string

--- a/htdocs/class/xoopseditor/tinymce/formtinymce.php
+++ b/htdocs/class/xoopseditor/tinymce/formtinymce.php
@@ -60,14 +60,6 @@ class XoopsFormTinymce extends XoopsEditor
     }
 
     /**
-     * @param $configs
-     */
-    public function XoopsFormTinymce($configs)
-    {
-        $this->__construct($configs);
-    }
-
-    /**
      * Renders the Javascript function needed for client-side for validation
      *
      * I'VE USED THIS EXAMPLE TO WRITE VALIDATION CODE

--- a/htdocs/class/xoopseditor/tinymce/tinymce.php
+++ b/htdocs/class/xoopseditor/tinymce/tinymce.php
@@ -22,7 +22,7 @@
  * @author              Laurent JEN <dugris@frxoops.org>
  * @version             $Id $
  */
-class tinymce
+class TinyMCE
 {
     public        $rootpath;
     public        $config                = array();
@@ -41,15 +41,6 @@ class tinymce
         $this->xoopsPlugins            = $this->get_xoopsPlugins();
         self::$LastOfElementsTinymce   = $this->config["elements"];
         self::$ListOfElementsTinymce[] = self::$LastOfElementsTinymce;
-    }
-
-    // PHP 4 Contructor
-    /**
-     * @param $config
-     */
-    public function TinyMCE($config)
-    {
-        $this->__construct($config);
     }
 
     /**

--- a/htdocs/class/xoopseditor/xoopseditor.php
+++ b/htdocs/class/xoopseditor/xoopseditor.php
@@ -67,14 +67,6 @@ class XoopsEditor extends XoopsFormTextArea
     }
 
     /**
-     * @param $configs
-     */
-    public function XoopsEditor($configs)
-    {
-        $this->__construct($configs);
-    }
-
-    /**
      * @return bool
      */
     public function isActive()
@@ -108,11 +100,6 @@ class XoopsEditorHandler
     public function __construct()
     {
         $this->root_path = XOOPS_ROOT_PATH . '/class/xoopseditor';
-    }
-
-    public function XoopsEditorHandler()
-    {
-        $this->__construct();
     }
 
     /**

--- a/htdocs/class/xoopsform/form.php
+++ b/htdocs/class/xoopsform/form.php
@@ -126,19 +126,6 @@ class XoopsForm
     }
 
     /**
-     * @param            $title
-     * @param            $name
-     * @param            $action
-     * @param string     $method
-     * @param bool|false $addtoken
-     * @param string     $summary
-     */
-    public function XoopsForm($title, $name, $action, $method = 'post', $addtoken = false, $summary = '')
-    {
-        $this->__construct($title, $name, $action, $method, $addtoken, $summary);
-    }
-
-    /**
      * *#@+
      * retrieves object serialisation/identification id (sha1 used)
      *

--- a/htdocs/class/xoopsform/formbutton.php
+++ b/htdocs/class/xoopsform/formbutton.php
@@ -73,17 +73,6 @@ class XoopsFormButton extends XoopsFormElement
     }
 
     /**
-     * @param        $caption
-     * @param        $name
-     * @param string $value
-     * @param string $type
-     */
-    public function XoopsFormButton($caption, $name, $value = "", $type = "button")
-    {
-        $this->__construct($caption, $name, $value, $type);
-    }
-
-    /**
      * Get the initial value
      *
      * @param  bool $encode To sanitizer the text?

--- a/htdocs/class/xoopsform/formbuttontray.php
+++ b/htdocs/class/xoopsform/formbuttontray.php
@@ -62,18 +62,6 @@ class XoopsFormButtonTray extends XoopsFormElement
     }
 
     /**
-     * @param            $name
-     * @param string     $value
-     * @param string     $type
-     * @param string     $onclick
-     * @param bool|false $showDelete
-     */
-    public function XoopsFormButtonTray($name, $value = '', $type = '', $onclick = '', $showDelete = false)
-    {
-        $this->__construct($name, $value, $type, $onclick, $showDelete);
-    }
-
-    /**
      * XoopsFormButtonTray::getValue()
      *
      * @return string

--- a/htdocs/class/xoopsform/formcaptcha.php
+++ b/htdocs/class/xoopsform/formcaptcha.php
@@ -73,17 +73,6 @@ class XoopsFormCaptcha extends XoopsFormElement
     }
 
     /**
-     * @param string    $caption
-     * @param string    $name
-     * @param bool|true $skipmember
-     * @param array     $configs
-     */
-    public function XoopsFormCaptcha($caption = '', $name = 'xoopscaptcha', $skipmember = true, $configs = array())
-    {
-        $this->__construct($caption, $name, $skipmember, $configs);
-    }
-
-    /**
      * @param $name
      * @param $val
      *

--- a/htdocs/class/xoopsform/formcheckbox.php
+++ b/htdocs/class/xoopsform/formcheckbox.php
@@ -79,17 +79,6 @@ class XoopsFormCheckBox extends XoopsFormElement
     }
 
     /**
-     * @param        $caption
-     * @param        $name
-     * @param null   $value
-     * @param string $delimeter
-     */
-    public function XoopsFormCheckBox($caption, $name, $value = null, $delimeter = '&nbsp;')
-    {
-        $this->__construct($caption, $name, $value, $delimeter);
-    }
-
-    /**
      * Get the "value"
      *
      * @param  bool $encode To sanitizer the text?

--- a/htdocs/class/xoopsform/formcolorpicker.php
+++ b/htdocs/class/xoopsform/formcolorpicker.php
@@ -44,16 +44,6 @@ class XoopsFormColorPicker extends XoopsFormText
     }
 
     /**
-     * @param        $caption
-     * @param        $name
-     * @param string $value
-     */
-    public function XoopsFormColorPicker($caption, $name, $value = '#FFFFFF')
-    {
-        $this->__construct($caption, $name, $value);
-    }
-
-    /**
      * XoopsFormColorPicker::render()
      *
      * @return string

--- a/htdocs/class/xoopsform/formdatetime.php
+++ b/htdocs/class/xoopsform/formdatetime.php
@@ -63,16 +63,4 @@ class XoopsFormDateTime extends XoopsFormElementTray
             $this->addElement(new XoopsFormHidden($name . '[time]', 0));
         }
     }
-
-    /**
-     * @param           $caption
-     * @param           $name
-     * @param int       $size
-     * @param int       $value
-     * @param bool|true $showtime
-     */
-    public function XoopsFormDateTime($caption, $name, $size = 15, $value = 0, $showtime = true)
-    {
-        $this->__construct($caption, $name, $size, $value, $showtime);
-    }
 }

--- a/htdocs/class/xoopsform/formeditor.php
+++ b/htdocs/class/xoopsform/formeditor.php
@@ -56,18 +56,6 @@ class XoopsFormEditor extends XoopsFormTextArea
     }
 
     /**
-     * @param            $caption
-     * @param            $name
-     * @param null       $configs
-     * @param bool|false $nohtml
-     * @param string     $OnFailure
-     */
-    public function XoopsFormEditor($caption, $name, $configs = null, $nohtml = false, $OnFailure = '')
-    {
-        $this->__construct($caption, $name, $configs, $nohtml, $OnFailure);
-    }
-
-    /**
      * renderValidationJS
      * TEMPORARY SOLUTION to 'override' original renderValidationJS method
      * with custom XoopsEditor's renderValidationJS method

--- a/htdocs/class/xoopsform/formelementtray.php
+++ b/htdocs/class/xoopsform/formelementtray.php
@@ -64,17 +64,6 @@ class XoopsFormElementTray extends XoopsFormElement
     }
 
     /**
-     * @param        $caption
-     * @param string $delimeter
-     * @param string $name
-     */
-//    public function XoopsFormElementTray($caption, $delimeter = "&nbsp;", $name = "")
-//    {
-//        $this->__construct($caption, $delimeter, $name);
-//    }
-
-
-    /**
      * Is this element a container of other elements?
      *
      * @return bool true

--- a/htdocs/class/xoopsform/formfile.php
+++ b/htdocs/class/xoopsform/formfile.php
@@ -48,16 +48,6 @@ class XoopsFormFile extends XoopsFormElement
     }
 
     /**
-     * @param $caption
-     * @param $name
-     * @param $maxfilesize
-     */
-    public function XoopsFormFile($caption, $name, $maxfilesize)
-    {
-        $this->__construct($caption, $name, $maxfilesize);
-    }
-
-    /**
      * Get the maximum filesize
      *
      * @return int

--- a/htdocs/class/xoopsform/formhidden.php
+++ b/htdocs/class/xoopsform/formhidden.php
@@ -48,15 +48,6 @@ class XoopsFormHidden extends XoopsFormElement
     }
 
     /**
-     * @param $name
-     * @param $value
-     */
-    public function XoopsFormHidden($name, $value)
-    {
-        $this->__construct($name, $value);
-    }
-
-    /**
      * Get the "value" attribute
      *
      * @param  bool $encode To sanitizer the text?

--- a/htdocs/class/xoopsform/formhiddentoken.php
+++ b/htdocs/class/xoopsform/formhiddentoken.php
@@ -35,13 +35,4 @@ class XoopsFormHiddenToken extends XoopsFormHidden
     {
         parent::__construct($name . '_REQUEST', $GLOBALS['xoopsSecurity']->createToken($timeout, $name));
     }
-
-    /**
-     * @param string $name
-     * @param int    $timeout
-     */
-    public function XoopsFormHiddenToken($name = 'XOOPS_TOKEN', $timeout = 0)
-    {
-        $this->__construct($name, $timeout);
-    }
 }

--- a/htdocs/class/xoopsform/formlabel.php
+++ b/htdocs/class/xoopsform/formlabel.php
@@ -48,16 +48,6 @@ class XoopsFormLabel extends XoopsFormElement
     }
 
     /**
-     * @param string $caption
-     * @param string $value
-     * @param string $name
-     */
-    public function XoopsFormLabel($caption = '', $value = '', $name = '')
-    {
-        $this->__construct($caption, $value, $name);
-    }
-
-    /**
      * Get the "value" attribute
      *
      * @param  bool $encode To sanitizer the text?

--- a/htdocs/class/xoopsform/formpassword.php
+++ b/htdocs/class/xoopsform/formpassword.php
@@ -80,19 +80,6 @@ class XoopsFormPassword extends XoopsFormElement
     }
 
     /**
-     * @param            $caption
-     * @param            $name
-     * @param            $size
-     * @param            $maxlength
-     * @param string     $value
-     * @param bool|false $autoComplete
-     */
-    public function XoopsFormPassword($caption, $name, $size, $maxlength, $value = '', $autoComplete = false)
-    {
-        $this->__construct($caption, $name, $size, $maxlength, $value, $autoComplete);
-    }
-
-    /**
      * Get the field size
      *
      * @return int

--- a/htdocs/class/xoopsform/formradio.php
+++ b/htdocs/class/xoopsform/formradio.php
@@ -74,17 +74,6 @@ class XoopsFormRadio extends XoopsFormElement
     }
 
     /**
-     * @param        $caption
-     * @param        $name
-     * @param null   $value
-     * @param string $delimeter
-     */
-    public function XoopsFormRadio($caption, $name, $value = null, $delimeter = '&nbsp;')
-    {
-        $this->__construct($caption, $name, $value, $delimeter);
-    }
-
-    /**
      * Get the "value" attribute
      *
      * @param  bool $encode To sanitizer the text?

--- a/htdocs/class/xoopsform/formradioyn.php
+++ b/htdocs/class/xoopsform/formradioyn.php
@@ -44,16 +44,4 @@ class XoopsFormRadioYN extends XoopsFormRadio
         $this->addOption(1, $yes);
         $this->addOption(0, $no);
     }
-
-    /**
-     * @param        $caption
-     * @param        $name
-     * @param null   $value
-     * @param string $yes
-     * @param string $no
-     */
-    public function XoopsFormRadioYN($caption, $name, $value = null, $yes = _YES, $no = _NO)
-    {
-        $this->__construct($caption, $name, $value, $yes, $no);
-    }
 }

--- a/htdocs/class/xoopsform/formselect.php
+++ b/htdocs/class/xoopsform/formselect.php
@@ -88,18 +88,6 @@ class XoopsFormSelect extends XoopsFormElement
     }
 
     /**
-     * @param            $caption
-     * @param            $name
-     * @param null       $value
-     * @param int        $size
-     * @param bool|false $multiple
-     */
-    public function XoopsFormSelect($caption, $name, $value = null, $size = 1, $multiple = false)
-    {
-        $this->__construct($caption, $name, $value, $size, $multiple);
-    }
-
-    /**
      * Are multiple selections allowed?
      *
      * @return bool

--- a/htdocs/class/xoopsform/formselectcheckgroup.php
+++ b/htdocs/class/xoopsform/formselectcheckgroup.php
@@ -56,16 +56,4 @@ class XoopsFormSelectCheckGroup extends XoopsFormCheckBox
             $this->addOption($group_id, $group_name);
         }
     }
-
-    /**
-     * @param            $caption
-     * @param            $name
-     * @param null       $value
-     * @param int        $size
-     * @param bool|false $multiple
-     */
-    public function XoopsFormSelectCheckGroup($caption, $name, $value = null, $size = 1, $multiple = false)
-    {
-        $this->__construct($caption, $name, $value, $size, $multiple);
-    }
 }

--- a/htdocs/class/xoopsform/formselectgroup.php
+++ b/htdocs/class/xoopsform/formselectgroup.php
@@ -50,17 +50,4 @@ class XoopsFormSelectGroup extends XoopsFormSelect
             $this->addOptionArray($member_handler->getGroupList());
         }
     }
-
-    /**
-     * @param            $caption
-     * @param            $name
-     * @param bool|false $include_anon
-     * @param null       $value
-     * @param int        $size
-     * @param bool|false $multiple
-     */
-    public function XoopsFormSelectGroup($caption, $name, $include_anon = false, $value = null, $size = 1, $multiple = false)
-    {
-        $this->__construct($caption, $name, $include_anon, $value, $size, $multiple);
-    }
 }

--- a/htdocs/class/xoopsform/formselectlang.php
+++ b/htdocs/class/xoopsform/formselectlang.php
@@ -42,15 +42,4 @@ class XoopsFormSelectLang extends XoopsFormSelect
         parent::__construct($caption, $name, $value, $size);
         $this->addOptionArray(XoopsLists::getLangList());
     }
-
-    /**
-     * @param      $caption
-     * @param      $name
-     * @param null $value
-     * @param int  $size
-     */
-    public function XoopsFormSelectLang($caption, $name, $value = null, $size = 1)
-    {
-        $this->__construct($caption, $name, $value, $size);
-    }
 }

--- a/htdocs/class/xoopsform/formselectmatchoption.php
+++ b/htdocs/class/xoopsform/formselectmatchoption.php
@@ -45,15 +45,4 @@ class XoopsFormSelectMatchOption extends XoopsFormSelect
         $this->addOption(XOOPS_MATCH_EQUAL, _MATCHES);
         $this->addOption(XOOPS_MATCH_CONTAIN, _CONTAINS);
     }
-
-    /**
-     * @param      $caption
-     * @param      $name
-     * @param null $value
-     * @param int  $size
-     */
-    public function XoopsFormSelectMatchOption($caption, $name, $value = null, $size = 1)
-    {
-        $this->__construct($caption, $name, $value, $size);
-    }
 }

--- a/htdocs/class/xoopsform/formselecttheme.php
+++ b/htdocs/class/xoopsform/formselecttheme.php
@@ -41,15 +41,4 @@ class XoopsFormSelectTheme extends XoopsFormSelect
         parent::__construct($caption, $name, $value, $size);
         $this->addOptionArray(XoopsLists::getThemesList());
     }
-
-    /**
-     * @param      $caption
-     * @param      $name
-     * @param null $value
-     * @param int  $size
-     */
-    public function XoopsFormSelectTheme($caption, $name, $value = null, $size = 1)
-    {
-        $this->__construct($caption, $name, $value, $size);
-    }
 }

--- a/htdocs/class/xoopsform/formselecttimezone.php
+++ b/htdocs/class/xoopsform/formselecttimezone.php
@@ -46,15 +46,4 @@ class XoopsFormSelectTimezone extends XoopsFormSelect
         parent::__construct($caption, $name, $value, $size);
         $this->addOptionArray(XoopsLists::getTimeZoneList());
     }
-
-    /**
-     * @param      $caption
-     * @param      $name
-     * @param null $value
-     * @param int  $size
-     */
-    public function XoopsFormSelectTimezone($caption, $name, $value = null, $size = 1)
-    {
-        $this->__construct($caption, $name, $value, $size);
-    }
 }

--- a/htdocs/class/xoopsform/formtext.php
+++ b/htdocs/class/xoopsform/formtext.php
@@ -68,18 +68,6 @@ class XoopsFormText extends XoopsFormElement
     }
 
     /**
-     * @param        $caption
-     * @param        $name
-     * @param        $size
-     * @param        $maxlength
-     * @param string $value
-     */
-    public function XoopsFormText($caption, $name, $size, $maxlength, $value = '')
-    {
-        $this->__construct($caption, $name, $size, $maxlength, $value);
-    }
-
-    /**
      * Get size
      *
      * @return int

--- a/htdocs/class/xoopsform/formtextdateselect.php
+++ b/htdocs/class/xoopsform/formtextdateselect.php
@@ -39,17 +39,6 @@ class XoopsFormTextDateSelect extends XoopsFormText
     }
 
     /**
-     * @param     $caption
-     * @param     $name
-     * @param int $size
-     * @param int $value
-     */
-    public function XoopsFormTextDateSelect($caption, $name, $size = 15, $value = 0)
-    {
-        $this->__construct($caption, $name, $size, $value);
-    }
-
-    /**
      * @return string
      */
     public function render()

--- a/htdocs/class/xoopsform/grouppermform.php
+++ b/htdocs/class/xoopsform/grouppermform.php
@@ -87,19 +87,6 @@ class XoopsGroupPermForm extends XoopsForm
     }
 
     /**
-     * @param           $title
-     * @param           $modid
-     * @param           $permname
-     * @param           $permdesc
-     * @param string    $url
-     * @param bool|true $anonymous
-     */
-    public function XoopsGroupPermForm($title, $modid, $permname, $permdesc, $url = '', $anonymous = true)
-    {
-        $this->__construct($title, $modid, $permname, $permdesc, $url, $anonymous);
-    }
-
-    /**
      * Adds an item to which permission will be assigned
      *
      * @param string $itemName
@@ -236,17 +223,6 @@ class XoopsGroupFormCheckBox extends XoopsFormElement
             $this->setValue($values);
         }
         $this->_groupId = $groupId;
-    }
-
-    /**
-     * @param      $caption
-     * @param      $name
-     * @param      $groupId
-     * @param null $values
-     */
-    public function XoopsGroupFormCheckBox($caption, $name, $groupId, $values = null)
-    {
-        $this->__construct($caption, $name, $groupId, $values);
     }
 
     /**

--- a/htdocs/class/xoopskernel.php
+++ b/htdocs/class/xoopskernel.php
@@ -41,11 +41,6 @@ class xos_kernel_Xoops2
         $this->paths['themes']  = array(XOOPS_ROOT_PATH . '/themes', XOOPS_URL . '/themes');
     }
 
-    public function xos_kernel_Xoops2()
-    {
-        $this->__construct();
-    }
-
     /**
      * Convert a XOOPS path to a physical one
      * @param               $url

--- a/htdocs/class/zipdownloader.php
+++ b/htdocs/class/zipdownloader.php
@@ -50,15 +50,6 @@ class XoopsZipDownloader extends XoopsDownloader
     }
 
     /**
-     * @param string $ext
-     * @param string $mimyType
-     */
-    public function XoopsZipDownloader($ext = '.zip', $mimyType = 'application/x-zip')
-    {
-        $this->__construct($ext, $mimyType);
-    }
-
-    /**
      * Add file
      *
      * @param string $filepath

--- a/htdocs/include/findusers.php
+++ b/htdocs/include/findusers.php
@@ -60,16 +60,6 @@ class XoopsRank extends XoopsObject
         $this->initVar('rank_special', XOBJ_DTYPE_INT, 0);
         $this->initVar('rank_image', XOBJ_DTYPE_TXTBOX, "");
     }
-
-    /**
-     * Xoops Rank
-     *
-     * @return XoopsRank
-     */
-    public function XoopsRank()
-    {
-        $this->__construct();
-    }
 }
 
 /**
@@ -86,17 +76,6 @@ class XoopsRankHandler extends XoopsObjectHandler
     public function __construct(XoopsDatabase $db)
     {
         parent::__construct($db);
-    }
-
-    /**
-     * Enter Xoops Ranks Handler
-     *
-     * @param  XoopsDatabase $db
-     * @return XoopsRankHandler
-     */
-    public function XoopsRankHandler(XoopsDatabase $db)
-    {
-        $this->__construct();
     }
 
     /**
@@ -198,16 +177,6 @@ class XoUser extends XoopsUser
             unset($this->vars[$var]);
         }
     }
-
-    /**
-     * XoUser
-     *
-     * @return XoUser
-     */
-    public function XoUser()
-    {
-        $this->__construct();
-    }
 }
 
 /**
@@ -224,17 +193,6 @@ class XoUserHandler extends XoopsObjectHandler
     public function __construct(XoopsDatabase $db)
     {
         parent::__construct($db);
-    }
-
-    /**
-     * Enter description here...
-     *
-     * @param  XoopsDatabase $db
-     * @return XoUserHandler
-     */
-    public function XoUserHandler(XoopsDatabase $db)
-    {
-        $this->__construct($db);
     }
 
     /**

--- a/htdocs/install/class/dbmanager.php
+++ b/htdocs/install/class/dbmanager.php
@@ -51,11 +51,6 @@ class db_manager
         $this->db->setLogger(XoopsLogger::getInstance());
     }
 
-    public function db_manager()
-    {
-        $this->__construct();
-    }
-
     /**
      * @return bool
      */

--- a/htdocs/install/class/pathcontroller.php
+++ b/htdocs/install/class/pathcontroller.php
@@ -93,15 +93,6 @@ class PathStuffController
         }
     }
 
-    /**
-     * @param $xoopsPathDefault
-     * @param $dataPath
-     */
-    public function PathStuffController($xoopsPathDefault, $dataPath)
-    {
-        $this->__construct($xoopsPathDefault, $dataPath);
-    }
-
     public function execute()
     {
         $this->readRequest();

--- a/htdocs/kernel/avatar.php
+++ b/htdocs/kernel/avatar.php
@@ -46,11 +46,6 @@ class XoopsAvatar extends XoopsObject
         $this->initVar('avatar_type', XOBJ_DTYPE_OTHER, 0, false);
     }
 
-    public function XoopsAvatar()
-    {
-        $this->__construct();
-    }
-
     /**
      * Returns Class Base Variable avatar_id
      * @param string $format

--- a/htdocs/kernel/block.php
+++ b/htdocs/kernel/block.php
@@ -71,14 +71,6 @@ class XoopsBlock extends XoopsObject
     }
 
     /**
-     * @param null $id
-     */
-    public function XoopsBlock($id = null)
-    {
-        $this->__construct($id);
-    }
-
-    /**
      * Returns Class Base Variable bid
      * @param string $format
      * @return mixed

--- a/htdocs/kernel/comment.php
+++ b/htdocs/kernel/comment.php
@@ -61,11 +61,6 @@ class XoopsComment extends XoopsObject
         $this->initVar('dobr', XOBJ_DTYPE_INT, 0, false);
     }
 
-    public function XoopsComment()
-    {
-        $this->__construct();
-    }
-
     /**
      * Returns Class Base Variable com_id
      * @param string $format

--- a/htdocs/kernel/config.php
+++ b/htdocs/kernel/config.php
@@ -70,14 +70,6 @@ class XoopsConfigHandler
     }
 
     /**
-     * @param XoopsDatabase $db
-     */
-    public function XoopsConfigHandler(XoopsDatabase $db)
-    {
-        $this->__construct($db);
-    }
-
-    /**
      * Create a config
      *
      * @see     XoopsConfigItem

--- a/htdocs/kernel/configcategory.php
+++ b/htdocs/kernel/configcategory.php
@@ -40,11 +40,6 @@ class XoopsConfigCategory extends XoopsObject
         $this->initVar('confcat_order', XOBJ_DTYPE_INT, 0);
     }
 
-    public function XoopsConfigCategory()
-    {
-        $this->__construct();
-    }
-
     /**
      * Returns Class Base Variable confcat_id
      * @param  string $format

--- a/htdocs/kernel/configitem.php
+++ b/htdocs/kernel/configitem.php
@@ -63,11 +63,6 @@ class XoopsConfigItem extends XoopsObject
         $this->initVar('conf_order', XOBJ_DTYPE_INT);
     }
 
-    public function XoopsConfigItem()
-    {
-        $this->__construct();
-    }
-
     /**
      * Returns Class Base Variable conf_id
      * @param  string $format

--- a/htdocs/kernel/configoption.php
+++ b/htdocs/kernel/configoption.php
@@ -40,11 +40,6 @@ class XoopsConfigOption extends XoopsObject
         $this->initVar('conf_id', XOBJ_DTYPE_INT, 0);
     }
 
-    public function XoopsConfigOption()
-    {
-        $this->__construct();
-    }
-
     /**
      * Returns Class Base Variable confop_id
      * @param  string $format

--- a/htdocs/kernel/group.php
+++ b/htdocs/kernel/group.php
@@ -39,11 +39,6 @@ class XoopsGroup extends XoopsObject
         $this->initVar('group_type', XOBJ_DTYPE_OTHER, null, false);
     }
 
-    public function XoopsGroup()
-    {
-        $this->__construct();
-    }
-
     /**
      * Returns Class Base Variable groupid
      * @param  string $format
@@ -265,11 +260,6 @@ class XoopsMembership extends XoopsObject
         $this->initVar('linkid', XOBJ_DTYPE_INT, null, false);
         $this->initVar('groupid', XOBJ_DTYPE_INT, null, false);
         $this->initVar('uid', XOBJ_DTYPE_INT, null, false);
-    }
-
-    public function XoopsMembership()
-    {
-        $this->__construct();
     }
 }
 

--- a/htdocs/kernel/groupperm.php
+++ b/htdocs/kernel/groupperm.php
@@ -44,11 +44,6 @@ class XoopsGroupPerm extends XoopsObject
         $this->initVar('gperm_name', XOBJ_DTYPE_OTHER, null, false);
     }
 
-    public function XoopsGroupPerm()
-    {
-        $this->__construct();
-    }
-
     /**
      * Returns Class Base Variable gperm_id
      * @param string $format

--- a/htdocs/kernel/image.php
+++ b/htdocs/kernel/image.php
@@ -44,11 +44,6 @@ class XoopsImage extends XoopsObject
         $this->initVar('imgcat_id', XOBJ_DTYPE_INT, 0, false);
     }
 
-    public function XoopsImage()
-    {
-        $this->__construct();
-    }
-
     /**
      * Returns Class Base Variable image_id
      * @param  string $format

--- a/htdocs/kernel/imagecategory.php
+++ b/htdocs/kernel/imagecategory.php
@@ -52,11 +52,6 @@ class XoopsImagecategory extends XoopsObject
         $this->initVar('imgcat_storetype', XOBJ_DTYPE_OTHER, null, false);
     }
 
-    public function XoopsImagecategory()
-    {
-        $this->__construct();
-    }
-
     /**
      * Returns Class Base Variable imgcat_id
      * @param  string $format

--- a/htdocs/kernel/imageset.php
+++ b/htdocs/kernel/imageset.php
@@ -43,11 +43,6 @@ class XoopsImageset extends XoopsObject
         $this->initVar('imgset_refid', XOBJ_DTYPE_INT, 0, false);
     }
 
-    public function XoopsImageset()
-    {
-        $this->__construct();
-    }
-
     /**
      * Returns Class Base Variable imgset_id
      * @param  string $format

--- a/htdocs/kernel/imagesetimg.php
+++ b/htdocs/kernel/imagesetimg.php
@@ -39,11 +39,6 @@ class XoopsImagesetimg extends XoopsObject
         $this->initVar('imgsetimg_imgset', XOBJ_DTYPE_INT, null, false);
     }
 
-    public function XoopsImagesetimg()
-    {
-        $this->__construct();
-    }
-
     /**
      * Returns Class Base Variable imgsetimg_id with default format N
      * @param  string $format

--- a/htdocs/kernel/member.php
+++ b/htdocs/kernel/member.php
@@ -67,14 +67,6 @@ class XoopsMemberHandler
     }
 
     /**
-     * @param XoopsDatabase $db
-     */
-    public function XoopsMemberHandler(XoopsDatabase $db)
-    {
-        $this->__construct($db);
-    }
-
-    /**
      * create a new group
      *
      * @return XoopsGroup XoopsGroup reference to the new group

--- a/htdocs/kernel/module.php
+++ b/htdocs/kernel/module.php
@@ -63,11 +63,6 @@ class XoopsModule extends XoopsObject
         $this->initVar('hasnotification', XOBJ_DTYPE_INT, 0, false);
     }
 
-    public function XoopsModule()
-    {
-        $this->__construct();
-    }
-
     /**
      * Load module info
      *

--- a/htdocs/kernel/notification.php
+++ b/htdocs/kernel/notification.php
@@ -49,11 +49,6 @@ class XoopsNotification extends XoopsObject
         $this->initVar('not_mode', XOBJ_DTYPE_INT, 0, false);
     }
 
-    public function XoopsNotification()
-    {
-        $this->__construct();
-    }
-
     // FIXME:???
     // To send email to multiple users simultaneously, we would need to move
     // the notify functionality to the handler class.  BUT, some of the tags

--- a/htdocs/kernel/object.php
+++ b/htdocs/kernel/object.php
@@ -116,11 +116,6 @@ class XoopsObject
     {
     }
 
-    public function XoopsObject()
-    {
-        $this->__construct();
-    }
-
     /**
      * *#@+
      * used for new/clone objects
@@ -1058,14 +1053,6 @@ class XoopsObjectHandler
     }
 
     /**
-     * @param XoopsDatabase $db
-     */
-    public function XoopsObjectHandler(XoopsDatabase $db)
-    {
-        $this->__construct($db);
-    }
-
-    /**
      * creates a new object
      *
      * @abstract
@@ -1182,21 +1169,6 @@ class XoopsPersistableObjectHandler extends XoopsObjectHandler
         if ($identifierName) {
             $this->identifierName = $identifierName;
         }
-    }
-
-    /**
-     * Constructor
-     *
-     * @access protected
-     * @param null   $db
-     * @param string $table
-     * @param string $className
-     * @param string $keyName
-     * @param string $identifierName
-     */
-    public function XoopsPersistableObjectHandler($db = null, $table = '', $className = '', $keyName = '', $identifierName = '')
-    {
-        $this->__construct($db, $table, $className, $keyName, $identifierName);
     }
 
     /**

--- a/htdocs/kernel/online.php
+++ b/htdocs/kernel/online.php
@@ -47,14 +47,6 @@ class XoopsOnlineHandler
     }
 
     /**
-     * @param XoopsDatabase $db
-     */
-    public function XoopsOnlineHandler(XoopsDatabase $db)
-    {
-        $this->__construct($db);
-    }
-
-    /**
      * Write online information to the database
      *
      * @param int    $uid    UID of the active user

--- a/htdocs/kernel/privmessage.php
+++ b/htdocs/kernel/privmessage.php
@@ -44,11 +44,6 @@ class XoopsPrivmessage extends XoopsObject
         $this->initVar('read_msg', XOBJ_DTYPE_INT, 0, false);
     }
 
-    public function XoopsPrivmessage()
-    {
-        $this->__construct();
-    }
-
     /**
      * Returns Class Base Variable msg_id
      * @param string $format

--- a/htdocs/kernel/session.php
+++ b/htdocs/kernel/session.php
@@ -73,14 +73,6 @@ class XoopsSessionHandler
     }
 
     /**
-     * @param XoopsDatabase $db
-     */
-    public function XoopsSessionHandler(XoopsDatabase $db)
-    {
-        $this->__construct($db);
-    }
-
-    /**
      * Open a session
      *
      * @param string $save_path

--- a/htdocs/kernel/tplfile.php
+++ b/htdocs/kernel/tplfile.php
@@ -49,11 +49,6 @@ class XoopsTplfile extends XoopsObject
         $this->initVar('tpl_source', XOBJ_DTYPE_SOURCE, null, false);
     }
 
-    public function XoopsTplfile()
-    {
-        $this->__construct();
-    }
-
     /**
      * Returns Class Base Variable tpl_id
      * @param  string $format

--- a/htdocs/kernel/tplset.php
+++ b/htdocs/kernel/tplset.php
@@ -42,11 +42,6 @@ class XoopsTplset extends XoopsObject
         $this->initVar('tplset_created', XOBJ_DTYPE_INT, 0, false);
     }
 
-    public function XoopsTplset()
-    {
-        $this->__construct();
-    }
-
     /**
      * Returns Class Base Variable tplset_id
      * @param  string $format

--- a/htdocs/kernel/user.php
+++ b/htdocs/kernel/user.php
@@ -102,14 +102,6 @@ class XoopsUser extends XoopsObject
     }
 
     /**
-     * @param null $id
-     */
-    public function XoopsUser($id = null)
-    {
-        $this->__construct($id);
-    }
-
-    /**
      * check if the user is a guest user
      *
      * @return bool returns false

--- a/htdocs/modules/pm/class/message.php
+++ b/htdocs/modules/pm/class/message.php
@@ -47,11 +47,6 @@ class PmMessage extends XoopsObject
         $this->initVar('from_save', XOBJ_DTYPE_INT, 0, false);
         $this->initVar('to_save', XOBJ_DTYPE_INT, 0, false);
     }
-
-    public function PmMessage()
-    {
-        $this->__construct();
-    }
 }
 
 /**
@@ -65,14 +60,6 @@ class PmMessageHandler extends XoopsPersistableObjectHandler
     public function __construct(XoopsDatabase $db)
     {
         parent::__construct($db, "priv_msgs", 'PmMessage', 'msg_id', 'subject');
-    }
-
-    /**
-     * @param XoopsDatabase $db
-     */
-    public function PmMessageHandler(XoopsDatabase $db)
-    {
-        $this->__construct($db);
     }
 
     /**

--- a/htdocs/modules/system/class/maintenance.php
+++ b/htdocs/modules/system/class/maintenance.php
@@ -39,11 +39,6 @@ class SystemMaintenance
         $this->prefix = $this->db->prefix . '_';
     }
 
-    public function SystemMaintenance()
-    {
-        $this->__construct();
-    }
-
     /**
      * Display Tables
      *

--- a/htdocs/modules/system/class/smilies.php
+++ b/htdocs/modules/system/class/smilies.php
@@ -40,11 +40,6 @@ class SystemSmilies extends XoopsObject
         $this->initVar('display', XOBJ_DTYPE_INT, null, false, 1);
     }
 
-    public function smilies()
-    {
-        $this->__construct();
-    }
-
     /**
      * @param bool $action
      *

--- a/htdocs/modules/system/themes/default/default.php
+++ b/htdocs/modules/system/themes/default/default.php
@@ -40,11 +40,6 @@ class XoopsGuiDefault extends XoopsSystemGui
     {
     }
 
-    public function XoopsGuiDefault()
-    {
-        $this->__construct();
-    }
-
     /**
      * @return bool
      */

--- a/htdocs/modules/system/themes/legacy/legacy.php
+++ b/htdocs/modules/system/themes/legacy/legacy.php
@@ -45,11 +45,6 @@ class XoopsGuiLegacy extends /* implements */
         include_once __DIR__ . "/cp_functions.php";
     }
 
-    public function XoopsGuiLegacy()
-    {
-        $this->__construct();
-    }
-
     /**
      * @return bool
      */

--- a/htdocs/modules/system/themes/thadmin/thadmin.php
+++ b/htdocs/modules/system/themes/thadmin/thadmin.php
@@ -43,11 +43,6 @@ class XoopsGuiThadmin extends /* implements */
         include_once XOOPS_ROOT_PATH . "/modules/thadmin/include/cp_functions.php";
     }
 
-    public function XoopsGuiThadmin()
-    {
-        $this->__construct();
-    }
-
     /**
      * @return bool
      */

--- a/htdocs/modules/system/themes/zetadigme/zetadigme.php
+++ b/htdocs/modules/system/themes/zetadigme/zetadigme.php
@@ -29,11 +29,6 @@ class XoopsGuiZetadigme extends XoopsSystemGui
     {
     }
 
-    public function XoopsGuiZetadigme()
-    {
-        $this->__construct();
-    }
-
     /**
      * @return bool
      */

--- a/htdocs/themes/xbootstrap/modules/publisher/xoops_and_module_changes/class/pagenav.php
+++ b/htdocs/themes/xbootstrap/modules/publisher/xoops_and_module_changes/class/pagenav.php
@@ -59,18 +59,6 @@ class XoopsPageNav
     }
 
     /**
-     * @param        $total_items
-     * @param        $items_perpage
-     * @param        $current_start
-     * @param string $start_name
-     * @param string $extra_arg
-     */
-    public function XoopsPageNav($total_items, $items_perpage, $current_start, $start_name = "start", $extra_arg = "")
-    {
-        $this->__construct($total_items, $items_perpage, $current_start, $start_name, $extra_arg);
-    }
-
-    /**
      * Create text navigation
      *
      * @param  integer $offset

--- a/htdocs/xoops_lib/modules/protector/class/ProtectorFilter.php
+++ b/htdocs/xoops_lib/modules/protector/class/ProtectorFilter.php
@@ -21,11 +21,6 @@ class ProtectorFilterAbstract
         }
     }
 
-    public function ProtectorFilterAbstract()
-    {
-        $this->__construct();
-    }
-
     /**
      * @return bool
      */
@@ -57,15 +52,10 @@ class ProtectorFilterHandler
     /**
      * ProtectorFilterHandler constructor.
      */
-    public function __construct()
+    protected function __construct()
     {
         $this->protector    =& Protector::getInstance();
         $this->filters_base = dirname(__DIR__) . '/filters_enabled';
-    }
-
-    public function ProtectorFilterHandler()
-    {
-        $this->__construct();
     }
 
     /**

--- a/htdocs/xoops_lib/modules/protector/class/ProtectorMysqlDatabase.class.php
+++ b/htdocs/xoops_lib/modules/protector/class/ProtectorMysqlDatabase.class.php
@@ -34,11 +34,6 @@ class ProtectorMySQLDatabase extends XoopsMySQLDatabaseProxy
         $this->doubtful_needles  = array_merge($this->doubtful_needles, $this->doubtful_requests);
     }
 
-    public function ProtectorMySQLDatabase()
-    {
-        $this->__construct();
-    }
-
     /**
      * @param $sql
      */

--- a/htdocs/xoops_lib/modules/protector/class/gtickets.php
+++ b/htdocs/xoops_lib/modules/protector/class/gtickets.php
@@ -41,10 +41,6 @@ if (!class_exists('XoopsGTicket')) {
             }
         }
 
-        public function XoopsGTicket()
-        {
-            $this->__construct();
-        }
         // render form as plain html
         /**
          * @param string $salt

--- a/htdocs/xoops_lib/modules/protector/class/protector.php
+++ b/htdocs/xoops_lib/modules/protector/class/protector.php
@@ -3,7 +3,7 @@
 /**
  * Class Protector
  */
-class protector
+class Protector
 {
     public $mydirname;
 
@@ -53,11 +53,10 @@ class protector
 
     public $last_error_type = 'UNKNOWN';
 
-    // Constructor
     /**
-     * @return bool
+     * Constructor
      */
-    public function Protector()
+    protected function __construct()
     {
         $this->mydirname = 'protector';
 
@@ -69,7 +68,7 @@ class protector
         }
 
         if (!empty($this->_conf['global_disabled'])) {
-            return true;
+            return;
         }
 
         // die if PHP_SELF XSS found (disabled in 2.53)
@@ -117,7 +116,7 @@ class protector
      * @param $val
      * @param $key
      */
-    public function _initial_recursive($val, $key)
+    protected function _initial_recursive($val, $key)
     {
         if (is_array($val)) {
             foreach ($val as $subkey => $subval) {
@@ -576,7 +575,7 @@ class protector
      * @param $val
      * @return null
      */
-    public function _dblayertrap_check_recursive($val)
+    protected function _dblayertrap_check_recursive($val)
     {
         if (is_array($val)) {
             foreach ($val as $subval) {
@@ -622,7 +621,7 @@ class protector
     /**
      * @param $val
      */
-    public function _bigumbrella_check_recursive($val)
+    protected function _bigumbrella_check_recursive($val)
     {
         if (is_array($val)) {
             foreach ($val as $subval) {
@@ -1228,7 +1227,7 @@ class protector
 
     //
     /**
-     * @return bool
+     * @return bool|null
      */
     public function check_brute_force()
     {
@@ -1270,12 +1269,13 @@ class protector
         }
         // delayed insert
         $xoopsDB->queryF($sql4insertlog);
+        return;
     }
 
     /**
      * @param $val
      */
-    public function _spam_check_point_recursive($val)
+    protected function _spam_check_point_recursive($val)
     {
         if (is_array($val)) {
             foreach ($val as $subval) {

--- a/htdocs/xoops_lib/modules/protector/class/registry.php
+++ b/htdocs/xoops_lib/modules/protector/class/registry.php
@@ -16,15 +16,10 @@ class ProtectorRegistry
     /**
      * ProtectorRegistry constructor.
      */
-    public function __construct()
+    protected function __construct()
     {
         $this->_entries = array();
         $this->_locks   = array();
-    }
-
-    public function ProtectorRegistry()
-    {
-        $this->__construct();
     }
 
     /**


### PR DESCRIPTION
Several classes had code similar to this:

```
class XoopsDatabaseFactory
{

    public function __construct()
    {
    }

    public function XoopsDatabaseFactory()
    {
        $this->__construct();
    }
```

In this example, in PHP4 (which we no longer support,) `function XoopsDatabaseFactory()` would the constructor. Now it serves no purpose, as it cannot be invoked without having already instantiated the class (so `__construct()` was already invoked.)

Also, some visibility changes where appropriate.